### PR TITLE
Added support for key value enums.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,15 @@ var types = {
 
   string: function (s) {
     if (s.hasOwnProperty('enum')) {
-      return enums.of(s['enum']);
+      if (Obj.is(s.enum)) {
+        return enums(s.enum);
+      }
+      else if (Arr.is(s.enum)) {
+        return enums.of(s['enum']);
+      }
+      else {
+        throw 'enum should be either an array of values or an object';
+      }
     }
     var predicate;
     if (s.hasOwnProperty('minLength')) {

--- a/test/test.js
+++ b/test/test.js
@@ -34,7 +34,7 @@ describe('transform', function () {
       eq(transform({type: 'string'}), Str);
     });
 
-    it('should handle enum', function () {
+    it('should handle array enum', function () {
       var Type = transform({
         type: 'string',
         'enum': ["Street", "Avenue", "Boulevard"]
@@ -42,6 +42,22 @@ describe('transform', function () {
       eq(getKind(Type), 'enums');
       eq(Type.is('a'), false);
       eq(Type.is('Street'), true);
+    });
+
+    it('should handle object enum', function () {
+      var Type = transform({
+        type: 'string',
+        'enum': {
+          'street': 'Street',
+          'avenue': 'Avenue',
+          'boulevard': 'Boulevard'
+        }
+      });
+      console.log(Type);
+      eq(getKind(Type), 'enums');
+      eq(Type.is('a'), false);
+      eq(Type.is('street'), true);
+      console.log(Type);
     });
 
     it('should handle minLength', function () {


### PR DESCRIPTION
Before this patch, only a list of string could be provided to the enum
attribute, leading to a list of options with the same name and value for
each entry of the list.

With this patch, you can still provide a list or if you want to gain
control over the name and value of the options, you can provide a
dictionnary whose key will become the name and value, well, the displayed value.

eg:

	{
	  "type": "object",
	  "properties": {
	    "number":      { "type": "number" },
	    "street_name": { "type": "string" },
	    "street_type": {
	      "type": "string",
	      "enum": ["Street", "Avenue", "Boulevard"]
	    }
	  }
	}
    OR
	{
	  "type": "object",
	  "properties": {
		"number":      { "type": "number" },
		"street_name": { "type": "string" },
		    "street_type": {
		      "type": "string",
		      "enum": {"street":"A Street", "avenue":"A nice avenue"}
		    }
	  }
	}