### PR TITLE
do not raise error when format is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,7 @@ var types = {
     if (s.hasOwnProperty('pattern')) {
       predicate = and(predicate, fcomb.regexp(new RegExp(s.pattern)));
     }
-    if (s.hasOwnProperty('format')) {
-      t.assert(formats.hasOwnProperty(s.format), '[tcomb-json-schema] Missing format ' + s.format + ', use the (format, predicate) API');
+    if (s.hasOwnProperty('format') && formats.hasOwnProperty(s.format)) {
       predicate = and(predicate, formats[s.format]);
     }
     return predicate ? t.subtype(t.String, predicate) : t.String;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/gcanti/tcomb-json-schema",
   "peerDependencies": {
-    "tcomb": "^2.2.0"
+    "tcomb": "^1.0.0"
   },
   "dependencies": {
     "fcomb": "^0.1.0"


### PR DESCRIPTION
Hi @gcanti,

Raising an error when format is missing does not work me. I've a "textarea" format that I use to render a `<textarea>` instead of a `<input>`... This format is not used for validation.

```json
{
  "bio": {
    "type": "string",
    "format": "textarea"
  }
}
```

To me, It does not seem that bad to do nothing when the format is missing. WDYT ?