### PR TITLE
Added possibility to define enums as objects to carry a value/label pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,30 @@ Removes all registered types.
 ```js
 transform.resetTypes();
 ```
+
+# JSON Schema
+
+## enums
+
+If you don't care of values you can describe enums as an array:
+
+
+```js
+"street_type": { 
+  "type": "string",
+  "enum": ["Street", "Avenue", "Boulevard"]
+}
+```
+
+or if you want to specify values, describe it as an object where the keys are the values:
+
+```js
+"street_type": { 
+  "type": "string",
+  "enum": {
+    st: "Street", 
+    ave: "Avenue", 
+    blvd: "Boulevard"
+  }
+}
+```

--- a/index.js
+++ b/index.js
@@ -14,7 +14,11 @@ var types = {
 
   string: function (s) {
     if (s.hasOwnProperty('enum')) {
-      return t.enums.of(s['enum']);
+      if (t.Array.is(s['enum'])) {
+        return t.enums.of(s['enum']);
+      } else {
+        return t.enums(s['enum']);
+      }
     }
     var predicate;
     if (s.hasOwnProperty('minLength')) {

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,16 @@ describe('transform', function () {
       eq(Type.is('Street'), true);
     });
 
+    it('should handle enum objects', function () {
+      var Type = transform({
+        type: 'string',
+        'enum': {st: "Street", ave: "Avenue", blvd: "Boulevard"}
+      });
+      eq(getKind(Type), 'enums');
+      eq(Type.is('a'), false);
+      eq(Type.is('st'), true);
+    });    
+
     it('should handle minLength', function () {
       var Type = transform({
         type: 'string',


### PR DESCRIPTION
This PR enables you to define enums as objects (as well as todays arrays). This way you can supply a value/label pair. Example:

```
street_type: {
  type: 'string',
  enum: {
    st: 'Street',
    ave: 'Avenue',
    blvd: 'Boulevard'
  }
}
```

Which is equivalent to defining the enum like this in tcomb:

```
t.enums({
    st: 'Street',
    ave: 'Avenue',
    blvd: 'Boulevard'
}, 'Street');
```

No breaking changes made. Valueless arrays can still be used:

```
street_type: {
  type: 'string',
  enum: [ 'Street', 'Avenue', 'Boulevard']
}
```

Added custom `isArray` method to keep compatible with <=IE8