### PR TITLE
Added possibility to define patterns with regex flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ transform.resetTypes();
 
 # JSON Schema
 
+## strings
+
+type `string` accepts the property `pattern` which will be used as a predicate (the value of the string must match the [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) defined in `pattern`). Example:
+
+```
+{
+  "type": "string",
+  "pattern": "^abc$"
+}
+```
+
+The pattern may be either
+
+* a simple string with a regex pattern, e.g. `^abc$` (example matching the exact word `abc`), or
+* a string version of a regex literal with a leading and trailing slash and optional [regex flags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags) after the last slash, e.g. `/^abc$/i` (example matching `abc` case insensetive)
+
 ## enums
 
 If you don't care of values you can describe enums as an array:

--- a/index.js
+++ b/index.js
@@ -28,7 +28,12 @@ var types = {
       predicate = and(predicate, fcomb.maxLength(s.maxLength));
     }
     if (s.hasOwnProperty('pattern')) {
-      predicate = and(predicate, fcomb.regexp(new RegExp(s.pattern)));
+      var patternMatch = /^\/(.+)\/([gimuy]*)$/.exec(s.pattern);
+      if (patternMatch === null) {
+        predicate = and(predicate, fcomb.regexp(new RegExp(s.pattern)));
+      } else {
+        predicate = and(predicate, fcomb.regexp(new RegExp(patternMatch[1], patternMatch[2])));
+      }
     }
     if (s.hasOwnProperty('format')) {
       t.assert(formats.hasOwnProperty(s.format), '[tcomb-json-schema] Missing format ' + s.format + ', use the (format, predicate) API');

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,17 @@ describe('transform', function () {
       eq(Type.meta.predicate('aaa'), false);
     });
 
+    it('should handle pattern as regex literal', function () {
+      var Type = transform({
+        type: 'string',
+        pattern: '/^H/i'
+      });
+      eq(getKind(Type), 'subtype');
+      eq(Type.meta.type, Str);
+      eq(Type.meta.predicate('hello'), true);
+      eq(Type.meta.predicate('aaa'), false);
+    });    
+
   });
 
   describe('number schema', function () {


### PR DESCRIPTION
As of today a pattern on a `string` may be described as: `^abc$` (example matching the exact word `abc`).

This PR also (without changing current behavior) adds the possibility to define patterns which is a string version of a regex literal - with a leading and trailing slash and optional [regex flags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags) after the last slash, e.g. `/^abc$/i` (example matching `abc` case insensitive)

This way we can add flags (such as _case insensitive_ in the example above)