### PR TITLE
closes #29 Date type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "extends": ["eslint:recommended", "prettier"],
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "mocha": true
   },
   "plugins": ["prettier"],
   "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 node_modules
+.vscode/

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ function and(f, g) {
 
 var types = {
   string: function(s) {
-    var type = t.String;
     if (s.hasOwnProperty('enum')) {
       if (t.Array.is(s['enum'])) {
         return t.enums.of(s['enum']);
@@ -48,16 +47,12 @@ var types = {
           s.format +
           ', use the (format, predicate) API'
       );
-      predicate = and(predicate, formats[s.format]);
-      if (
-        s.format === 'date' ||
-        s.format === 'date-time' ||
-        s.format === 'time'
-      ) {
-        type = t.Date;
+      if (t.isType(formats[s.format])) {
+        return formats[s.format];
       }
+      predicate = and(predicate, formats[s.format]);
     }
-    return predicate ? t.subtype(type, predicate) : type;
+    return predicate ? t.subtype(t.String, predicate) : t.String;
   },
 
   number: function(s) {
@@ -169,12 +164,12 @@ function transform(s) {
 
 var formats = {};
 
-transform.registerFormat = function registerFormat(format, predicate) {
+transform.registerFormat = function registerFormat(format, predicateOrType) {
   t.assert(
     !formats.hasOwnProperty(format),
     '[tcomb-json-schema] Duplicated format ' + format
   );
-  formats[format] = predicate;
+  formats[format] = predicateOrType;
 };
 
 transform.resetFormats = function resetFormats() {

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function and(f, g) {
 
 var types = {
   string: function(s) {
+    var type = t.String;
     if (s.hasOwnProperty('enum')) {
       if (t.Array.is(s['enum'])) {
         return t.enums.of(s['enum']);
@@ -48,8 +49,15 @@ var types = {
           ', use the (format, predicate) API'
       );
       predicate = and(predicate, formats[s.format]);
+      if (
+        s.format === 'date' ||
+        s.format === 'date-time' ||
+        s.format === 'time'
+      ) {
+        type = t.Date;
+      }
     }
-    return predicate ? t.subtype(t.String, predicate) : t.String;
+    return predicate ? t.subtype(type, predicate) : type;
   },
 
   number: function(s) {

--- a/test/test.js
+++ b/test/test.js
@@ -450,16 +450,12 @@ describe('transform', function() {
   });
 
   describe('date format', function() {
-    function isDate(x) {
-      return x instanceof Date;
-    }
-
-    transform.registerFormat('date', isDate);
+    transform.registerFormat('date', Dat);
 
     it('should throw if duplicated formats are registered', function() {
       assert.throws(
         function() {
-          transform.registerFormat('date', isDate);
+          transform.registerFormat('date', Dat);
         },
         function(err) {
           if (
@@ -479,9 +475,8 @@ describe('transform', function() {
         default: '',
         description: 'Date of your departure'
       });
-      eq(getKind(Type), 'subtype');
-      ok(Type.meta.type === Dat);
-      ok(Type.meta.predicate === isDate);
+      eq(getKind(Type), 'irreducible');
+      ok(Type === Dat);
       ok(Type.is(new Date('2000-10-23')));
       ko(Type.is('2000.10.23'));
     });

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
-"use strict";
+'use strict';
+
 var assert = require('assert');
 var t = require('tcomb');
 var transform = require('../index');
@@ -10,7 +11,8 @@ var Bool = t.Bool;
 var Obj = t.Obj;
 var Arr = t.Arr;
 var Any = t.Any;
-var getKind = function (type) {
+var Dat = t.Date;
+var getKind = function(type) {
   return type.meta.kind;
 };
 
@@ -18,43 +20,45 @@ var getKind = function (type) {
 // setup
 //
 
-var ok = function (x) { assert.strictEqual(true, x); };
-var ko = function (x) { assert.strictEqual(false, x); };
+var ok = function(x) {
+  assert.strictEqual(true, x);
+};
+var ko = function(x) {
+  assert.strictEqual(false, x);
+};
 var eq = assert.strictEqual;
 
-describe('transform', function () {
-
-  it('should transform an empty schema', function () {
+describe('transform', function() {
+  it('should transform an empty schema', function() {
     eq(transform({}), Any);
   });
 
-  describe('string schema', function () {
-
-    it('should transform a simple schema', function () {
-      eq(transform({type: 'string'}), Str);
+  describe('string schema', function() {
+    it('should transform a simple schema', function() {
+      eq(transform({ type: 'string' }), Str);
     });
 
-    it('should handle enum', function () {
+    it('should handle enum', function() {
       var Type = transform({
         type: 'string',
-        'enum': ["Street", "Avenue", "Boulevard"]
+        enum: ['Street', 'Avenue', 'Boulevard']
       });
       eq(getKind(Type), 'enums');
       eq(Type.is('a'), false);
       eq(Type.is('Street'), true);
     });
 
-    it('should handle enum objects', function () {
+    it('should handle enum objects', function() {
       var Type = transform({
         type: 'string',
-        'enum': {st: "Street", ave: "Avenue", blvd: "Boulevard"}
+        enum: { st: 'Street', ave: 'Avenue', blvd: 'Boulevard' }
       });
       eq(getKind(Type), 'enums');
       eq(Type.is('a'), false);
       eq(Type.is('st'), true);
-    });    
+    });
 
-    it('should handle minLength', function () {
+    it('should handle minLength', function() {
       var Type = transform({
         type: 'string',
         minLength: 2
@@ -65,7 +69,7 @@ describe('transform', function () {
       eq(Type.meta.predicate('aa'), true);
     });
 
-    it('should handle maxLength', function () {
+    it('should handle maxLength', function() {
       var Type = transform({
         type: 'string',
         maxLength: 2
@@ -76,7 +80,7 @@ describe('transform', function () {
       eq(Type.meta.predicate('aaa'), false);
     });
 
-    it('should handle pattern', function () {
+    it('should handle pattern', function() {
       var Type = transform({
         type: 'string',
         pattern: '^h'
@@ -87,7 +91,7 @@ describe('transform', function () {
       eq(Type.meta.predicate('aaa'), false);
     });
 
-    it('should handle pattern as regex literal', function () {
+    it('should handle pattern as regex literal', function() {
       var Type = transform({
         type: 'string',
         pattern: '/^H/i'
@@ -96,17 +100,15 @@ describe('transform', function () {
       eq(Type.meta.type, Str);
       eq(Type.meta.predicate('hello'), true);
       eq(Type.meta.predicate('aaa'), false);
-    });    
-
+    });
   });
 
-  describe('number schema', function () {
-
-    it('should transform a simple schema', function () {
-      eq(transform({type: 'number'}), Num);
+  describe('number schema', function() {
+    it('should transform a simple schema', function() {
+      eq(transform({ type: 'number' }), Num);
     });
 
-    it('should handle minimum', function () {
+    it('should handle minimum', function() {
       var Type = transform({
         type: 'number',
         minimum: 2
@@ -118,7 +120,7 @@ describe('transform', function () {
       eq(Type.meta.predicate(3), true);
     });
 
-    it('should handle exclusiveMinimum', function () {
+    it('should handle exclusiveMinimum', function() {
       var Type = transform({
         type: 'number',
         minimum: 2,
@@ -131,7 +133,7 @@ describe('transform', function () {
       eq(Type.meta.predicate(3), true);
     });
 
-    it('should handle maximum', function () {
+    it('should handle maximum', function() {
       var Type = transform({
         type: 'number',
         maximum: 2
@@ -143,7 +145,7 @@ describe('transform', function () {
       eq(Type.meta.predicate(3), false);
     });
 
-    it('should handle exclusiveMaximum', function () {
+    it('should handle exclusiveMaximum', function() {
       var Type = transform({
         type: 'number',
         maximum: 2,
@@ -156,7 +158,7 @@ describe('transform', function () {
       eq(Type.meta.predicate(3), false);
     });
 
-    it('should handle integer', function () {
+    it('should handle integer', function() {
       var Type = transform({
         type: 'number',
         integer: true
@@ -166,12 +168,10 @@ describe('transform', function () {
       eq(Type.meta.predicate(1), true);
       eq(Type.meta.predicate(1.1), false);
     });
-
   });
 
-  describe('integer schema', function () {
-
-    it('should transform a simple schema', function () {
+  describe('integer schema', function() {
+    it('should transform a simple schema', function() {
       var Type = transform({
         type: 'integer'
       });
@@ -180,7 +180,7 @@ describe('transform', function () {
       eq(Type.is(1.1), false);
     });
 
-    it('should handle minimum', function () {
+    it('should handle minimum', function() {
       var Type = transform({
         type: 'integer',
         minimum: 2
@@ -192,7 +192,7 @@ describe('transform', function () {
       eq(Type.meta.predicate(3), true);
     });
 
-    it('should handle exclusiveMinimum', function () {
+    it('should handle exclusiveMinimum', function() {
       var Type = transform({
         type: 'integer',
         minimum: 2,
@@ -205,7 +205,7 @@ describe('transform', function () {
       eq(Type.meta.predicate(3), true);
     });
 
-    it('should handle maximum', function () {
+    it('should handle maximum', function() {
       var Type = transform({
         type: 'integer',
         maximum: 2
@@ -217,7 +217,7 @@ describe('transform', function () {
       eq(Type.meta.predicate(3), false);
     });
 
-    it('should handle exclusiveMaximum', function () {
+    it('should handle exclusiveMaximum', function() {
       var Type = transform({
         type: 'integer',
         maximum: 2,
@@ -229,33 +229,31 @@ describe('transform', function () {
       eq(Type.meta.predicate(2), false);
       eq(Type.meta.predicate(3), false);
     });
-
   });
 
-  it('should transform a null schema', function () {
-    var Type = transform({type: 'null'});
+  it('should transform a null schema', function() {
+    var Type = transform({ type: 'null' });
     ok(Type === util.Null);
     ok(Type.is(null));
     ko(Type.is(undefined));
     ko(Type.is('a'));
   });
 
-  it('should transform a boolean schema', function () {
-    eq(transform({type: 'boolean'}), Bool);
+  it('should transform a boolean schema', function() {
+    eq(transform({ type: 'boolean' }), Bool);
   });
 
-  describe('object schema', function () {
-
-    it('should transform a simple schema', function () {
-      eq(transform({type: 'object'}), Obj);
+  describe('object schema', function() {
+    it('should transform a simple schema', function() {
+      eq(transform({ type: 'object' }), Obj);
     });
 
-    it('should handle optional properties', function () {
+    it('should handle optional properties', function() {
       var Type = transform({
         type: 'object',
         properties: {
-          a: {type: 'string'},
-          b: {type: 'number'}
+          a: { type: 'string' },
+          b: { type: 'number' }
         }
       });
       var a = Type.meta.props.a;
@@ -266,12 +264,12 @@ describe('transform', function () {
       ok(b.meta.type === Num);
     });
 
-    it('should handle required properties', function () {
+    it('should handle required properties', function() {
       var Type = transform({
         type: 'object',
         properties: {
-          a: {type: 'string'},
-          b: {type: 'number'}
+          a: { type: 'string' },
+          b: { type: 'number' }
         },
         required: ['a']
       });
@@ -282,32 +280,30 @@ describe('transform', function () {
       eq(getKind(b), 'maybe');
       ok(b.meta.type === Num);
     });
-
   });
 
-  describe('array schema', function () {
-
-    it('should transform a simple schema', function () {
-      eq(transform({type: 'array'}), Arr);
+  describe('array schema', function() {
+    it('should transform a simple schema', function() {
+      eq(transform({ type: 'array' }), Arr);
     });
 
-    it('should handle minItems', function () {
-      var Type = transform({type: 'array', minItems: 1});
+    it('should handle minItems', function() {
+      var Type = transform({ type: 'array', minItems: 1 });
       eq(getKind(Type), 'subtype');
       eq(Type.meta.type, Arr);
       eq(Type.meta.predicate([]), false);
       eq(Type.meta.predicate(['a']), true);
     });
 
-    it('should handle maxItems', function () {
-      var Type = transform({type: 'array', maxItems: 2});
+    it('should handle maxItems', function() {
+      var Type = transform({ type: 'array', maxItems: 2 });
       eq(getKind(Type), 'subtype');
       eq(Type.meta.type, Arr);
       eq(Type.meta.predicate(['a', 'b']), true);
       eq(Type.meta.predicate(['a', 'b', 'c']), false);
     });
 
-    it('should handle list items', function () {
+    it('should handle list items', function() {
       var Type = transform({
         type: 'array',
         items: {
@@ -318,170 +314,231 @@ describe('transform', function () {
       ok(Type.meta.type === Num);
     });
 
-    it('should handle minItems with list items', function () {
+    it('should handle minItems with list items', function() {
       var Type = transform({
-        "type": "array",
-        "minItems": 2,
-        "items": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
+        type: 'array',
+        minItems: 2,
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string'
             }
           },
-          "required": ["name"]
+          required: ['name']
         }
-      })
+      });
       eq(getKind(Type), 'subtype');
       eq(getKind(Type.meta.type), 'list');
       eq(getKind(Type.meta.type.meta.type), 'struct');
       eq(Type.meta.predicate([]), false);
-      eq(Type.meta.predicate([{name: 'name 1'}]), false);
-      eq(Type.meta.predicate([{name: 'name 1'}, {name: 'name 2'}]), true);
-      eq(Type.meta.predicate([{name: 'name 1'}, {name: 'name 2'}, {name: 'name 3'}]), true);
-    })
+      eq(Type.meta.predicate([{ name: 'name 1' }]), false);
+      eq(Type.meta.predicate([{ name: 'name 1' }, { name: 'name 2' }]), true);
+      eq(
+        Type.meta.predicate([
+          { name: 'name 1' },
+          { name: 'name 2' },
+          { name: 'name 3' }
+        ]),
+        true
+      );
+    });
 
-    it('should handle maxItems with list items', function () {
+    it('should handle maxItems with list items', function() {
       var Type = transform({
-        "type": "array",
-        "maxItems": 2,
-        "items": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
+        type: 'array',
+        maxItems: 2,
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string'
             }
           },
-          "required": ["name"]
+          required: ['name']
         }
-      })
+      });
       eq(getKind(Type), 'subtype');
       eq(getKind(Type.meta.type), 'list');
       eq(getKind(Type.meta.type.meta.type), 'struct');
       eq(Type.meta.predicate([]), true);
-      eq(Type.meta.predicate([{name: 'name 1'}]), true);
-      eq(Type.meta.predicate([{name: 'name 1'}, {name: 'name 2'}]), true);
-      eq(Type.meta.predicate([{name: 'name 1'}, {name: 'name 2'}, {name: 'name 3'}]), false);
-    })
+      eq(Type.meta.predicate([{ name: 'name 1' }]), true);
+      eq(Type.meta.predicate([{ name: 'name 1' }, { name: 'name 2' }]), true);
+      eq(
+        Type.meta.predicate([
+          { name: 'name 1' },
+          { name: 'name 2' },
+          { name: 'name 3' }
+        ]),
+        false
+      );
+    });
 
-    it('should handle tuple items', function () {
+    it('should handle tuple items', function() {
       var Type = transform({
         type: 'array',
-        items: [
-          {type: 'string'},
-          {type: 'number'}
-        ]
+        items: [{ type: 'string' }, { type: 'number' }]
       });
       eq(getKind(Type), 'tuple');
       ok(Type.meta.types[0] === Str);
       ok(Type.meta.types[1] === Num);
     });
-
   });
 
-  it('should handle unions', function () {
-    var Type = transform({type: ["number", "string"]});
+  it('should handle unions', function() {
+    var Type = transform({ type: ['number', 'string'] });
     eq(getKind(Type), 'union');
     ok(Type.meta.types[0] === Num);
     ok(Type.meta.types[1] === Str);
   });
 
-  describe('registerFormat', function () {
-
+  describe('registerFormat', function() {
     function isEmail(x) {
       return /(.)+@(.)+/.test(x);
     }
 
     transform.registerFormat('email', isEmail);
 
-    it('should throw if duplicated formats are registered', function () {
+    it('should throw if duplicated formats are registered', function() {
       assert.throws(
-        function () {
+        function() {
           transform.registerFormat('email', isEmail);
         },
         function(err) {
-          if ( (err instanceof Error) && err.message === '[tcomb] [tcomb-json-schema] Duplicated format email') {
+          if (
+            err instanceof Error &&
+            err.message ===
+              '[tcomb] [tcomb-json-schema] Duplicated format email'
+          ) {
             return true;
           }
         }
       );
     });
 
-    it('should throw if unknown formats are used', function () {
+    it('should throw if unknown formats are used', function() {
       assert.throws(
-        function () {
-          var Type = transform({
-            type: "string",
+        function() {
+          transform({
+            type: 'string',
             format: 'unknown'
           });
         },
         function(err) {
-          if ( (err instanceof Error) && err.message === '[tcomb] [tcomb-json-schema] Missing format unknown, use the (format, predicate) API') {
+          if (
+            err instanceof Error &&
+            err.message ===
+              '[tcomb] [tcomb-json-schema] Missing format unknown, use the (format, predicate) API'
+          ) {
             return true;
           }
         }
       );
     });
 
-    it('should handle format property', function () {
+    it('should handle format property', function() {
       var Type = transform({
-        type: "string",
+        type: 'string',
         format: 'email'
       });
       eq(getKind(Type), 'subtype');
       ok(Type.meta.type === Str);
       ok(Type.meta.predicate === isEmail);
       ok(Type.is('a@b'));
-      ko(Type.is(''))
+      ko(Type.is(''));
     });
-
   });
 
-	describe('registerType', function () {
+  describe('date format', function() {
+    function isDate(x) {
+      return x instanceof Date;
+    }
 
-	  var Str10 = t.subtype(t.Str, function (s) {
-	    return s.length <= 10;
-	  }, 'Str10');
+    transform.registerFormat('date', isDate);
 
-		transform.registerType('string10', Str10);
-
-    it('should throw if duplicated types are registered', function () {
+    it('should throw if duplicated formats are registered', function() {
       assert.throws(
-        function () {
+        function() {
+          transform.registerFormat('date', isDate);
+        },
+        function(err) {
+          if (
+            err instanceof Error &&
+            err.message === '[tcomb] [tcomb-json-schema] Duplicated format date'
+          ) {
+            return true;
+          }
+        }
+      );
+    });
+
+    it('should handle date', function() {
+      var Type = transform({
+        type: 'string',
+        format: 'date',
+        default: '',
+        description: 'Date of your departure'
+      });
+      eq(getKind(Type), 'subtype');
+      ok(Type.meta.type === Dat);
+      ok(Type.meta.predicate === isDate);
+      ok(Type.is(new Date('2000-10-23')));
+      ko(Type.is('2000.10.23'));
+    });
+  });
+
+  describe('registerType', function() {
+    var Str10 = t.subtype(
+      t.Str,
+      function(s) {
+        return s.length <= 10;
+      },
+      'Str10'
+    );
+
+    transform.registerType('string10', Str10);
+
+    it('should throw if duplicated types are registered', function() {
+      assert.throws(
+        function() {
           transform.registerType('string10', Str10);
         },
         function(err) {
-          if ( (err instanceof Error) && err.message === '[tcomb] [tcomb-json-schema] Duplicated type string10') {
+          if (
+            err instanceof Error &&
+            err.message ===
+              '[tcomb] [tcomb-json-schema] Duplicated type string10'
+          ) {
             return true;
           }
         }
       );
     });
 
-    it('should throw if a reserved type is register', function () {
+    it('should throw if a reserved type is register', function() {
       assert.throws(
-        function () {
+        function() {
           transform.registerType('string', Str10);
         },
         function(err) {
-          if ( (err instanceof Error) && err.message === '[tcomb] [tcomb-json-schema] Reserved type string') {
+          if (
+            err instanceof Error &&
+            err.message === '[tcomb] [tcomb-json-schema] Reserved type string'
+          ) {
             return true;
           }
         }
       );
     });
 
-
-    it('should handle type property', function () {
+    it('should handle type property', function() {
       var Type = transform({
-        type: "string10"
+        type: 'string10'
       });
       eq(getKind(Type), 'subtype');
       ok(Type.meta.type === Str);
       ok(Type.is('abcdefghij'));
-      ko(Type.is('abcdefghijk'))
+      ko(Type.is('abcdefghijk'));
     });
-
   });
-
 });


### PR DESCRIPTION
Adds support for date types. JSON schema doesn't support dates and sends them as string with an added 'date', 'time' or 'date-time' format. This handles the case.