### PR TITLE
Type override for enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var TcombType = transform({
 
 ## registerFormat(format: string, predicateOrType: (x: any) => boolean | Type): void
 
-Registers a new format.
+Registers a new format for string types. If you're using any format in the json-schema you need to register it before the transformation.
 
 **Example**
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,23 @@ function and(f, g) {
 
 var types = {
   string: function(s) {
+    var predicate, formatPredicate;
+
+    if (s.hasOwnProperty('format')) {
+      t.assert(
+        formats.hasOwnProperty(s.format),
+        '[tcomb-json-schema] Missing format ' +
+          s.format +
+          ', use the (format, predicate) API'
+      );
+
+      if (t.isType(formats[s.format])) {
+        return formats[s.format];
+      }
+
+      formatPredicate = formats[s.format];
+    }
+
     if (s.hasOwnProperty('enum')) {
       if (t.Array.is(s['enum'])) {
         return t.enums.of(s['enum']);
@@ -22,7 +39,7 @@ var types = {
         return t.enums(s['enum']);
       }
     }
-    var predicate;
+
     if (s.hasOwnProperty('minLength')) {
       predicate = and(predicate, fcomb.minLength(s.minLength));
     }
@@ -40,18 +57,11 @@ var types = {
         );
       }
     }
-    if (s.hasOwnProperty('format')) {
-      t.assert(
-        formats.hasOwnProperty(s.format),
-        '[tcomb-json-schema] Missing format ' +
-          s.format +
-          ', use the (format, predicate) API'
-      );
-      if (t.isType(formats[s.format])) {
-        return formats[s.format];
-      }
-      predicate = and(predicate, formats[s.format]);
+
+    if (formatPredicate) {
+      predicate = and(predicate, formatPredicate);
     }
+
     return predicate ? t.subtype(t.String, predicate) : t.String;
   },
 

--- a/test/test.js
+++ b/test/test.js
@@ -447,6 +447,24 @@ describe('transform', function() {
       ok(Type.is('a@b'));
       ko(Type.is(''));
     });
+
+    it('should favour format types over any other type', function() {
+      var TestNumType = t.subtype(Num, function(val) {
+        return Boolean(~[2, 3].indexOf(val));
+      });
+
+      transform.registerFormat('number-type', TestNumType);
+
+      var Type = transform({
+        type: 'string',
+        format: 'number-type',
+        enum: [1, 2]
+      });
+      eq(getKind(Type), 'subtype');
+      ok(Type.meta.type === Num);
+      ok(Type.is(2));
+      ko(Type.is(1));
+    });
   });
 
   describe('date format', function() {


### PR DESCRIPTION
Added ability to override enum types by moving the "format type check" to the first thing in the string handler. I think it's reasonable to allow consumers to override enum types as well.

Also a comment to explain the format override system only works for strings.