### PR TITLE
Check all required properties are defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,9 @@ var types = {
     var required = {};
     if (s.required) {
       s.required.forEach(function(k) {
+        if (!s.properties.hasOwnProperty(k)) {
+          t.fail('[tcomb-json-schema] Missing required property ' + k);
+        }
         required[k] = true;
       });
     }


### PR DESCRIPTION
This ensure that if a property is marked as required, that it exists in the definition of properties in a struct.